### PR TITLE
✨ Search in conversations

### DIFF
--- a/src/components/messages.tsx
+++ b/src/components/messages.tsx
@@ -31,7 +31,7 @@ function Messages() {
 
   useEffect(() => {
     if (selectedCharmer) getConversationMessages(user!.id, selectedCharmer)
-  }, [selectedCharmer])
+  }, [selectedCharmer, contentFilter])
 
   useEffect(() => {
     if (currentChannelId) getChannelMessages(currentChannelId)

--- a/src/stores/useMessagesStore.ts
+++ b/src/stores/useMessagesStore.ts
@@ -16,7 +16,7 @@ type MessagesStore = {
 
 const useMessagesStore = create<MessagesStore>((set, get) => ({
   messages: [],
-  contentFilter: "*",
+  contentFilter: "",
   conversationId: null,
   addMessage: async (message: MessageRecord) => {
     set(({ messages }) => ({ messages: [message, ...messages] }))
@@ -31,7 +31,7 @@ const useMessagesStore = create<MessagesStore>((set, get) => ({
       .from("messages")
       .select("*, charmer:charmer_id(name)")
       .order("created_at", { ascending: false })
-      .like("content", `%${get().contentFilter ?? "*"}%`)
+      .like("content", `%${get().contentFilter}%`)
       .eq("channel_id", id)) as MessagesResponse
 
     if (error) console.error(error)
@@ -42,7 +42,7 @@ const useMessagesStore = create<MessagesStore>((set, get) => ({
 
     let { data: messages, error } = (await supabase.rpc(
       "get_conversation_messages",
-      { id1: userId, id2: charmerId }
+      { id1: userId, id2: charmerId, filter: `%${get().contentFilter}%` }
     )) as MessagesResponse
 
     if (error) console.error(error)


### PR DESCRIPTION
Apparently, `contentFilter` was not added as a dependency on the effect that triggers a conversation request, therefore no filter was happening for 1-1 messages.

Apart from these changes, the `rpc` database function was adapted so it can receive a `filter` parameter.

Another minor tweak, was the use of an empty string as the default `contentFilter` state value and the removal of `"*"` as the _empty filter_ representation (it's actually not needed and prone to non-desired behavior).